### PR TITLE
destructure simulation parameters from test environment, #21

### DIFF
--- a/refactor/config_data/params.json
+++ b/refactor/config_data/params.json
@@ -1,0 +1,26 @@
+{
+  "seed": {
+    "description": "Global seed to use in the simulations",
+    "value": 0
+  },
+  "f_meanEMB": {
+    "description": "Mean of Emamectin Benzoate",
+    "value": 3.5
+  },
+  "f_sigEMB": {
+    "description": "Standard deviation of Emamectin Benzoate",
+    "value": 0.7
+  },
+  "env_meanEMB": {
+    "description": "Mean Emamectin Benzoate in the environment",
+    "value": 0.0
+  },
+  "env_sigEMB": {
+    "description": "Standard deviation of Emamectin Benzoate in the environment",
+    "value": 1.0
+  },
+  "EMBmort": {
+    "description": "Probability of mortality due to Emamectin Benzoate",
+    "value": 0.9
+  }
+}

--- a/refactor/src/Config.py
+++ b/refactor/src/Config.py
@@ -17,11 +17,12 @@ def to_dt(string_date):
 
 class Config:
 
-    def __init__(self, config_file, logger):
+    def __init__(self, environment_file, param_file, logger):
         """Simulation configuration and parameters
 
-        :param config_file: Path to the JSON file
-        :type config_file: string
+        :param environment_file: Path to the environment JSON file
+        :type environment_file: string
+        :param param_file: path to the simulator parameters JSON file
         :param logger: Logger to be used
         :type logger: logging.Logger
         """
@@ -30,8 +31,10 @@ class Config:
         self.logger = logger
 
         # read and set the params
-        with open(config_file) as f:
+        with open(environment_file) as f:
             data = json.load(f)
+
+        self.params = RuntimeConfig(param_file)
 
         # time and dates
         self.start_date = to_dt(data["start_date"]["value"])
@@ -56,13 +59,32 @@ class Config:
         self.reservoir_num_fish = data["reservoir"]["value"]["num_fish"]["value"]
 
         # treatment
-        treatment_data = data["treatment"]["value"]
-        self.f_meanEMB = treatment_data["f_meanEMB"]["value"]
-        self.f_sigEMB = treatment_data["f_sigEMB"]["value"]
-        self.env_meanEMB = treatment_data["env_meanEMB"]["value"]
-        self.env_sigEMB = treatment_data["env_sigEMB"]["value"]
-        self.EMBmort = treatment_data["EMBmort"]["value"]
+        #treatment_data = data["treatment"]["value"]
+        #self.f_meanEMB = treatment_data["f_meanEMB"]["value"]
+        #self.f_sigEMB = treatment_data["f_sigEMB"]["value"]
+        #self.env_meanEMB = treatment_data["env_meanEMB"]["value"]
+        #self.env_sigEMB = treatment_data["env_sigEMB"]["value"]
+        #self.EMBmort = treatment_data["EMBmort"]["value"]
 
+    def __getattr__(self, name):
+        # obscure marshalling trick
+        params = self.__getattribute__("params")
+        if name in dir(params):
+            return params.__getattribute__(name)
+        return self.__getattribute__(name)
+
+class RuntimeConfig:
+    """Simulation parameters and constants"""
+
+    def __init__(self, hyperparam_file):
+        with open(hyperparam_file) as f:
+            data = json.load(f)
+
+        self.f_meanEMB = data["f_meanEMB"]["value"]
+        self.f_sigEMB = data["f_sigEMB"]["value"]
+        self.env_meanEMB = data["env_meanEMB"]["value"]
+        self.env_sigEMB = data["env_sigEMB"]["value"]
+        self.EMBmort = data["EMBmort"]["value"]
 
 class FarmConfig:
 

--- a/refactor/src/SeaLiceMgmt.py
+++ b/refactor/src/SeaLiceMgmt.py
@@ -142,7 +142,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Sea lice simulation")
     parser.add_argument("path", type=str, help="Output directory path")
     parser.add_argument("id", type=str, help="Experiment name")
+    parser.add_argument("sim_path", type=str, help="Path to simulation params JSON file")
     parser.add_argument("cfg_path", type=str, help="Path to config JSON file")
+    parser.add_argument("--seed", type=int, help="Provide a seed. Overrides the param", required=False)
     args = parser.parse_args()
 
     # set up the data folders
@@ -151,7 +153,9 @@ if __name__ == "__main__":
 
     # set up config class and logger (logging to file and screen.)
     logger = create_logger()
-    cfg = Config(args.cfg_path, logger)
+    cfg = Config(args.cfg_path, args.sim_path, logger)
+    if "seed" in args:
+        cfg.params.seed = args.seed
 
     # run the simulation
     FARMS, RESERVOIR = initialise(output_folder, args.id, cfg)


### PR DESCRIPTION
Plan
- [ ] Move all magic numbers in the new file (e.g. Aldrin/Stien's estimations)
    - [x] EMB treatment numbers
    - [ ] Mortality rates
    - [ ] Development rates and medians
    - [ ] Reservoir numbers
    - [ ] Miscellaneous constants
- [x] Extend CLI to override runtime params
    - [x] seed

Will likely cause merge conflicts with #22 and #29 . Also, the current approach relies on `__getattr__` marshalling, quite a hack but it allows to keep much of the code unchanged.